### PR TITLE
Replace tokio traits with futures traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,5 +61,6 @@ libc = "0.2.141"
 
 [dev-dependencies]
 tokio = { version = "1.27.0", features = ["io-std", "io-util", "macros", "process", "rt", "time"] }
+tokio-util = { version = "0.7.8", features = ["compat"] }
 tower = "0.4.13"
 tracing-subscriber = "0.3.16"

--- a/examples/client_builder.rs
+++ b/examples/client_builder.rs
@@ -14,8 +14,8 @@ use lsp_types::{
     TextDocumentItem, TextDocumentPositionParams, Url, WindowClientCapabilities, WorkDoneProgress,
     WorkDoneProgressParams,
 };
-use tokio::io::BufReader;
 use tokio::sync::oneshot;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tower::ServiceBuilder;
 use tracing::{info, Level};
 
@@ -73,8 +73,8 @@ async fn main() {
         .kill_on_drop(true)
         .spawn()
         .expect("Failed run rust-analyzer");
-    let stdout = BufReader::new(child.stdout.unwrap());
-    let stdin = child.stdin.unwrap();
+    let stdout = TokioAsyncReadCompatExt::compat(child.stdout.unwrap());
+    let stdin = TokioAsyncWriteCompatExt::compat_write(child.stdin.unwrap());
 
     let frontend_fut = tokio::spawn(async move {
         frontend.run(stdout, stdin).await.unwrap();

--- a/examples/client_trait.rs
+++ b/examples/client_trait.rs
@@ -14,8 +14,8 @@ use lsp_types::{
     TextDocumentPositionParams, Url, WindowClientCapabilities, WorkDoneProgress,
     WorkDoneProgressParams,
 };
-use tokio::io::BufReader;
 use tokio::sync::oneshot;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tower::ServiceBuilder;
 use tracing::{info, Level};
 
@@ -90,8 +90,8 @@ async fn main() {
         .kill_on_drop(true)
         .spawn()
         .expect("Failed run rust-analyzer");
-    let stdout = BufReader::new(child.stdout.unwrap());
-    let stdin = child.stdin.unwrap();
+    let stdout = TokioAsyncReadCompatExt::compat(child.stdout.unwrap());
+    let stdin = TokioAsyncWriteCompatExt::compat_write(child.stdin.unwrap());
 
     let frontend_fut = tokio::spawn(async move {
         frontend.run(stdout, stdin).await.unwrap();

--- a/examples/server_builder.rs
+++ b/examples/server_builder.rs
@@ -13,7 +13,6 @@ use lsp_types::{
     notification, request, Hover, HoverContents, HoverProviderCapability, InitializeResult,
     MarkedString, MessageType, OneOf, ServerCapabilities, ShowMessageParams,
 };
-use tokio::io::BufReader;
 use tower::ServiceBuilder;
 use tracing::{info, Level};
 
@@ -104,7 +103,7 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    let stdin = BufReader::new(PipeStdin::lock().unwrap());
+    let stdin = PipeStdin::lock().unwrap();
     let stdout = PipeStdout::lock().unwrap();
     server.run(stdin, stdout).await.unwrap();
 }

--- a/examples/server_trait.rs
+++ b/examples/server_trait.rs
@@ -15,7 +15,6 @@ use lsp_types::{
     HoverContents, HoverParams, HoverProviderCapability, InitializeParams, InitializeResult,
     MarkedString, MessageType, OneOf, ServerCapabilities, ShowMessageParams,
 };
-use tokio::io::BufReader;
 use tower::ServiceBuilder;
 use tracing::{info, Level};
 
@@ -127,7 +126,7 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    let stdin = BufReader::new(PipeStdin::lock().unwrap());
+    let stdin = PipeStdin::lock().unwrap();
     let stdout = PipeStdout::lock().unwrap();
     server.run(stdin, stdout).await.unwrap();
 }

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use async_lsp::stdio::{PipeStdin, PipeStdout};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use futures::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::timeout;
 
 #[tokio::main(flavor = "current_thread")]


### PR DESCRIPTION
This replaces the `AsyncReadBuf` and `AsyncWrite` traits from `tokio` with those from `futures`. These changes add a compat translation layer on child processes or other `AsyncRead`/`AsyncWrite` coming out of Tokio, but makes the library more ergonomic for various build targets.

I encountered this difference when compiling the server example to wasm32 and creating the stdin/stdout with `wasm-streams` which produces streams that implement `AsyncRead` and `AsyncWrite` from `futures`.

I also noticed that the `BufReader::new` seemed to be always needed, as a lot of libraries are just producing `AsyncRead`, so I moved that call into `run`.