### PR TITLE
Relax associated type bounds on `LspService`

### DIFF
--- a/src/client_monitor.rs
+++ b/src/client_monitor.rs
@@ -25,8 +25,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 use crate::{
-    AnyEvent, AnyNotification, AnyRequest, ClientSocket, Error, JsonValue, LspService,
-    ResponseError, Result,
+    AnyEvent, AnyNotification, AnyRequest, ClientSocket, Error, LspService, ResponseError, Result,
 };
 
 struct ClientProcessExited;
@@ -40,7 +39,7 @@ pub struct ClientProcessMonitor<S> {
 }
 
 impl<S: LspService> Service<AnyRequest> for ClientProcessMonitor<S> {
-    type Response = JsonValue;
+    type Response = S::Response;
     type Error = ResponseError;
     type Future = S::Future;
 

--- a/src/client_monitor.rs
+++ b/src/client_monitor.rs
@@ -24,9 +24,7 @@ use lsp_types::request::{self, Request};
 use tower_layer::Layer;
 use tower_service::Service;
 
-use crate::{
-    AnyEvent, AnyNotification, AnyRequest, ClientSocket, Error, LspService, ResponseError, Result,
-};
+use crate::{AnyEvent, AnyNotification, AnyRequest, ClientSocket, Error, LspService, Result};
 
 struct ClientProcessExited;
 
@@ -40,7 +38,7 @@ pub struct ClientProcessMonitor<S> {
 
 impl<S: LspService> Service<AnyRequest> for ClientProcessMonitor<S> {
     type Response = S::Response;
-    type Error = ResponseError;
+    type Error = S::Error;
     type Future = S::Future;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -23,8 +23,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 use crate::{
-    AnyEvent, AnyNotification, AnyRequest, ErrorCode, JsonValue, LspService, RequestId,
-    ResponseError, Result,
+    AnyEvent, AnyNotification, AnyRequest, ErrorCode, LspService, RequestId, ResponseError, Result,
 };
 
 /// The middleware for incoming request multiplexing limits and cancellation.
@@ -41,7 +40,7 @@ pub struct Concurrency<S> {
 define_getters!(impl[S] Concurrency<S>, service: S);
 
 impl<S: LspService> Service<AnyRequest> for Concurrency<S> {
-    type Response = JsonValue;
+    type Response = S::Response;
     type Error = ResponseError;
     type Future = ResponseFuture<S::Future>;
 
@@ -124,7 +123,10 @@ pin_project! {
     }
 }
 
-impl<Fut: Future<Output = Result<JsonValue, ResponseError>>> Future for ResponseFuture<Fut> {
+impl<Response, Fut> Future for ResponseFuture<Fut>
+where
+    Fut: Future<Output = Result<Response, ResponseError>>,
+{
     type Output = Fut::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub enum Error {
 }
 
 /// The core service abstraction, representing either a Language Server or Language Client.
-pub trait LspService: Service<AnyRequest, Response = JsonValue, Error = ResponseError> {
+pub trait LspService: Service<AnyRequest, Error = ResponseError> {
     /// The handler of [LSP notifications](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage).
     ///
     /// Notifications are delivered in order and synchronously. This is mandatory since they can
@@ -477,7 +477,7 @@ enum MainLoopEvent {
 
 define_getters!(impl[S: LspService] MainLoop<S>, service: S);
 
-impl<S: LspService> MainLoop<S> {
+impl<S: LspService<Response = JsonValue>> MainLoop<S> {
     /// Create a Language Server main loop.
     #[must_use]
     pub fn new_server(builder: impl FnOnce(ClientSocket) -> S) -> (Self, ClientSocket) {
@@ -845,7 +845,7 @@ mod tests {
         output: impl AsyncWrite + Send,
     ) -> impl Send
     where
-        S: LspService + Send,
+        S: LspService<Response = JsonValue> + Send,
         S::Future: Send,
     {
         f.run(input, output)

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -17,14 +17,14 @@ use crate::{AnyEvent, AnyNotification, AnyRequest, ErrorCode, LspService, Respon
 /// The middleware catching panics of underlying handlers and turn them into error responses.
 ///
 /// See [module level documentations](self) for details.
-pub struct CatchUnwind<S> {
+pub struct CatchUnwind<S: LspService> {
     service: S,
-    handler: Handler,
+    handler: Handler<S::Error>,
 }
 
-define_getters!(impl[S] CatchUnwind<S>, service: S);
+define_getters!(impl[S: LspService] CatchUnwind<S>, service: S);
 
-type Handler = fn(method: &str, payload: Box<dyn Any + Send>) -> ResponseError;
+type Handler<E> = fn(method: &str, payload: Box<dyn Any + Send>) -> E;
 
 fn default_handler(method: &str, payload: Box<dyn Any + Send>) -> ResponseError {
     let msg = match payload.downcast::<String>() {
@@ -43,8 +43,8 @@ fn default_handler(method: &str, payload: Box<dyn Any + Send>) -> ResponseError 
 
 impl<S: LspService> Service<AnyRequest> for CatchUnwind<S> {
     type Response = S::Response;
-    type Error = ResponseError;
-    type Future = ResponseFuture<S::Future>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, S::Error>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.service.poll_ready(cx)
@@ -72,30 +72,30 @@ impl<S: LspService> Service<AnyRequest> for CatchUnwind<S> {
 
 pin_project! {
     /// The [`Future`] type used by the [`CatchUnwind`] middleware.
-    pub struct ResponseFuture<Fut> {
+    pub struct ResponseFuture<Fut, Error> {
         #[pin]
-        inner: ResponseFutureInner<Fut>,
+        inner: ResponseFutureInner<Fut, Error>,
     }
 }
 
 pin_project! {
     #[project = ResponseFutureProj]
-    enum ResponseFutureInner<Fut> {
+    enum ResponseFutureInner<Fut, Error> {
         Future {
             #[pin]
             fut: Fut,
             method: String,
-            handler: Handler,
+            handler: Handler<Error>,
         },
         Ready {
-            err: Option<ResponseError>,
+            err: Option<Error>,
         },
     }
 }
 
-impl<Response, Fut> Future for ResponseFuture<Fut>
+impl<Response, Fut, Error> Future for ResponseFuture<Fut, Error>
 where
-    Fut: Future<Output = Result<Response, ResponseError>>,
+    Fut: Future<Output = Result<Response, Error>>,
 {
     type Output = Fut::Output;
 
@@ -134,28 +134,28 @@ impl<S: LspService> LspService for CatchUnwind<S> {
 /// The error code is set to [`ErrorCode::INTERNAL_ERROR`].
 #[derive(Clone)]
 #[must_use]
-pub struct CatchUnwindBuilder {
-    handler: Handler,
+pub struct CatchUnwindBuilder<Error = ResponseError> {
+    handler: Handler<Error>,
 }
 
-impl Default for CatchUnwindBuilder {
+impl Default for CatchUnwindBuilder<ResponseError> {
     fn default() -> Self {
         Self::new_with_handler(default_handler)
     }
 }
 
-impl CatchUnwindBuilder {
+impl<Error> CatchUnwindBuilder<Error> {
     /// Create the builder of [`CatchUnwind`] middleware with a custom handler converting panic
     /// payloads into [`ResponseError`].
-    pub fn new_with_handler(handler: Handler) -> Self {
+    pub fn new_with_handler(handler: Handler<Error>) -> Self {
         Self { handler }
     }
 }
 
 /// A type alias of [`CatchUnwindBuilder`] conforming to the naming convention of [`tower_layer`].
-pub type CatchUnwindLayer = CatchUnwindBuilder;
+pub type CatchUnwindLayer<Error = ResponseError> = CatchUnwindBuilder<Error>;
 
-impl<S> Layer<S> for CatchUnwindBuilder {
+impl<S: LspService> Layer<S> for CatchUnwindBuilder<S::Error> {
     type Service = CatchUnwind<S>;
 
     fn layer(&self, inner: S) -> Self::Service {

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,8 +21,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 use crate::{
-    AnyEvent, AnyNotification, AnyRequest, Error, ErrorCode, JsonValue, LspService, ResponseError,
-    Result,
+    AnyEvent, AnyNotification, AnyRequest, Error, ErrorCode, LspService, ResponseError, Result,
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -57,7 +56,7 @@ impl<S> Lifecycle<S> {
 }
 
 impl<S: LspService> Service<AnyRequest> for Lifecycle<S> {
-    type Response = JsonValue;
+    type Response = S::Response;
     type Error = ResponseError;
     type Future = ResponseFuture<S::Future>;
 
@@ -134,8 +133,8 @@ pin_project! {
     }
 }
 
-impl<Fut: Future<Output = Result<JsonValue, ResponseError>>> Future for ResponseFuture<Fut> {
-    type Output = Result<JsonValue, ResponseError>;
+impl<Fut: Future> Future for ResponseFuture<Fut> {
+    type Output = Fut::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.project().inner.poll(cx)

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -19,7 +19,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 use tracing::{info_span, Span};
 
-use crate::{AnyEvent, AnyNotification, AnyRequest, LspService, ResponseError, Result};
+use crate::{AnyEvent, AnyNotification, AnyRequest, LspService, Result};
 
 /// The middleware attaching [`tracing::Span`]s over underlying handlers.
 ///
@@ -34,7 +34,7 @@ define_getters!(impl[S] Tracing<S>, service: S);
 
 impl<S: LspService> Service<AnyRequest> for Tracing<S> {
     type Response = S::Response;
-    type Error = ResponseError;
+    type Error = S::Error;
     type Future = ResponseFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -19,7 +19,7 @@ use tower_layer::Layer;
 use tower_service::Service;
 use tracing::{info_span, Span};
 
-use crate::{AnyEvent, AnyNotification, AnyRequest, JsonValue, LspService, ResponseError, Result};
+use crate::{AnyEvent, AnyNotification, AnyRequest, LspService, ResponseError, Result};
 
 /// The middleware attaching [`tracing::Span`]s over underlying handlers.
 ///
@@ -33,7 +33,7 @@ pub struct Tracing<S> {
 define_getters!(impl[S] Tracing<S>, service: S);
 
 impl<S: LspService> Service<AnyRequest> for Tracing<S> {
-    type Response = JsonValue;
+    type Response = S::Response;
     type Error = ResponseError;
     type Future = ResponseFuture<S::Future>;
 
@@ -59,7 +59,7 @@ pin_project! {
     }
 }
 
-impl<Fut: Future<Output = Result<JsonValue, ResponseError>>> Future for ResponseFuture<Fut> {
+impl<Fut: Future> Future for ResponseFuture<Fut> {
     type Output = Fut::Output;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {


### PR DESCRIPTION
These bounds are moved to `MainLoop` impls and middlewares. `Error: From<ResponseError>` or `ResponseError: From<Error>` is used when errors are produced or consumed in the impl.

Should fix #3. @phated Does this approach fix for you?