### PR TITLE
chore: fix typo in `run_bufferred`

### DIFF
--- a/examples/client_builder.rs
+++ b/examples/client_builder.rs
@@ -86,7 +86,7 @@ async fn main() {
     let stdin = child.stdin.unwrap();
 
     let mainloop_fut = tokio::spawn(async move {
-        mainloop.run_bufferred(stdout, stdin).await.unwrap();
+        mainloop.run_buffered(stdout, stdin).await.unwrap();
     });
 
     // Initialize.

--- a/examples/client_trait.rs
+++ b/examples/client_trait.rs
@@ -103,7 +103,7 @@ async fn main() {
     let stdin = child.stdin.unwrap();
 
     let mainloop_fut = tokio::spawn(async move {
-        mainloop.run_bufferred(stdout, stdin).await.unwrap();
+        mainloop.run_buffered(stdout, stdin).await.unwrap();
     });
 
     // Initialize.

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -123,11 +123,11 @@ async fn main() {
 
     let child_stdin = child.stdin.take().unwrap();
     let child_stdout = child.stdout.take().unwrap();
-    let main1 = tokio::spawn(mock_client.run_bufferred(child_stdout, child_stdin));
+    let main1 = tokio::spawn(mock_client.run_buffered(child_stdout, child_stdin));
 
     let stdin = tokio::io::stdin().compat();
     let stdout = tokio::io::stdout().compat_write();
-    let main2 = tokio::spawn(mock_server.run_bufferred(stdin, stdout));
+    let main2 = tokio::spawn(mock_server.run_buffered(stdin, stdout));
 
     let ret = tokio::select! {
         ret = main1 => ret,

--- a/examples/server_builder.rs
+++ b/examples/server_builder.rs
@@ -115,5 +115,5 @@ async fn main() {
         tokio_util::compat::TokioAsyncWriteCompatExt::compat_write(tokio::io::stdout()),
     );
 
-    server.run_bufferred(stdin, stdout).await.unwrap();
+    server.run_buffered(stdin, stdout).await.unwrap();
 }

--- a/examples/server_trait.rs
+++ b/examples/server_trait.rs
@@ -138,5 +138,5 @@ async fn main() {
         tokio_util::compat::TokioAsyncWriteCompatExt::compat_write(tokio::io::stdout()),
     );
 
-    server.run_bufferred(stdin, stdout).await.unwrap();
+    server.run_buffered(stdin, stdout).await.unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ where
     /// [`BufReader`].
     // Documented in `Self::run`.
     #[allow(clippy::missing_errors_doc)]
-    pub async fn run_bufferred(self, input: impl AsyncRead, output: impl AsyncWrite) -> Result<()> {
+    pub async fn run_buffered(self, input: impl AsyncRead, output: impl AsyncWrite) -> Result<()> {
         self.run(BufReader::new(input), output).await
     }
 

--- a/tests/unit_test.rs
+++ b/tests/unit_test.rs
@@ -93,14 +93,14 @@ async fn mock_server_and_client() {
     let (server_rx, server_tx) = server_stream.compat().split();
     let server_main = tokio::spawn(async move {
         server_main
-            .run_bufferred(server_rx, server_tx)
+            .run_buffered(server_rx, server_tx)
             .await
             .unwrap();
     });
     let (client_rx, client_tx) = client_stream.compat().split();
     let client_main = tokio::spawn(async move {
         let err = client_main
-            .run_bufferred(client_rx, client_tx)
+            .run_buffered(client_rx, client_tx)
             .await
             .unwrap_err();
         assert!(


### PR DESCRIPTION
Hey! Thank you for your work on this, I'm another user of this library over at https://github.com/noir-lang/noir

Apologies for nitpicky nature of the PR but typos in function names are a pet peeve of mine.