### PR TITLE
Functionality for composing and routing to different LSP services

### DIFF
--- a/src/can_handle.rs
+++ b/src/can_handle.rs
@@ -1,0 +1,10 @@
+//! Provides the `CanHandle` trait for services to indicate their ability to handle
+//! specific message types. Useful for composing multiple Services/LspServices and
+//! routing messages.
+//!
+
+/// Indicates whether a service can handle a specific message type.
+pub trait CanHandle<Message> {
+    /// Returns `true` if the service can handle the given message.
+    fn can_handle(&self, e: &Message) -> bool;
+}

--- a/src/steer.rs
+++ b/src/steer.rs
@@ -1,0 +1,366 @@
+//! Provides routing for LSP requests, notifications, and events.
+//!
+//! Key components:
+//!
+//! - `LspPicker`: Trait for custom service selection.
+//! - `FirstComeFirstServe`: Basic `LspPicker` implementation.
+//! - `LspSteer`: Manages multiple LSP services using a picker.
+//!
+//! Enables flexible routing for LSP operations with customizable service selection.
+
+use crate::can_handle::CanHandle;
+use crate::{AnyEvent, AnyNotification, AnyRequest, LspService, Result};
+use std::ops::ControlFlow;
+use std::task::{Context, Poll};
+use tower_service::Service;
+
+/// A trait for implementing custom service selection strategies in an LSP router.
+///
+/// This trait allows you to define how requests, notifications, and events
+/// should be distributed among multiple LSP services.
+pub trait LspPicker<S> {
+    /// Selects a service to handle a given request.
+    ///
+    /// # Arguments
+    ///
+    /// * `req` - The request to be handled.
+    /// * `services` - A slice of available services.
+    ///
+    /// # Returns
+    ///
+    /// The index of the selected service in the `services` slice.
+    fn pick(&mut self, req: &AnyRequest, services: &[S]) -> usize;
+
+    /// Selects a service to handle a given notification.
+    ///
+    /// # Arguments
+    ///
+    /// * `notif` - The notification to be handled.
+    /// * `services` - A slice of available services.
+    ///
+    /// # Returns
+    ///
+    /// The index of the selected service in the `services` slice.
+    fn pick_notification(&mut self, notif: &AnyNotification, services: &[S]) -> usize;
+
+    /// Selects a service to handle a given event.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The event to be handled.
+    /// * `services` - A slice of available services.
+    ///
+    /// # Returns
+    ///
+    /// The index of the selected service in the `services` slice.
+    fn pick_event(&mut self, event: &AnyEvent, services: &[S]) -> usize;
+}
+
+impl<S, FN, FE, F> LspPicker<S> for (FN, FE, F)
+where
+    F: Fn(&AnyRequest, &[S]) -> usize,
+    FN: Fn(&AnyNotification, &[S]) -> usize,
+    FE: Fn(&AnyEvent, &[S]) -> usize,
+{
+    fn pick_notification(&mut self, notif: &AnyNotification, services: &[S]) -> usize {
+        self.0(notif, services)
+    }
+    fn pick_event(&mut self, event: &AnyEvent, services: &[S]) -> usize {
+        self.1(event, services)
+    }
+    fn pick(&mut self, req: &AnyRequest, services: &[S]) -> usize {
+        self.2(req, services)
+    }
+}
+
+/// A picker that selects the first service that can handle a given request, notification, or event.
+pub struct FirstComeFirstServe;
+
+impl<S> LspPicker<S> for FirstComeFirstServe
+where
+    S: CanHandle<AnyNotification> + CanHandle<AnyRequest> + CanHandle<AnyEvent>,
+{
+    fn pick_notification(&mut self, notif: &AnyNotification, services: &[S]) -> usize {
+        services
+            .iter()
+            .position(|service| service.can_handle(notif))
+            .unwrap_or(0)
+    }
+
+    fn pick_event(&mut self, event: &AnyEvent, services: &[S]) -> usize {
+        services
+            .iter()
+            .position(|service| service.can_handle(event))
+            .unwrap_or(0)
+    }
+
+    fn pick(&mut self, req: &AnyRequest, services: &[S]) -> usize {
+        services
+            .iter()
+            .position(|service| service.can_handle(req))
+            .unwrap_or(0)
+    }
+}
+
+/// A struct that steers LSP requests, notifications, and events to the appropriate service.
+///
+/// `LspSteer` manages a collection of LSP services and uses a picker to determine
+/// which service should handle each incoming request, notification, or event.
+pub struct LspSteer<S, P> {
+    /// The collection of LSP services managed by this `LspSteer`.
+    services: Vec<S>,
+    /// The picker used to select the appropriate service for each operation.
+    picker: P,
+}
+
+impl<S, P> LspSteer<S, P>
+where
+    P: LspPicker<S>,
+{
+    /// Creates a new `LspSteer` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `services` - An iterator of LSP services to be managed by this `LspSteer`.
+    /// * `picker` - The picker implementation used to select services.
+    ///
+    /// # Returns
+    ///
+    /// A new `LspSteer` instance with the provided services and picker.
+    pub fn new(services: impl IntoIterator<Item = S>, picker: P) -> Self {
+        Self {
+            services: services.into_iter().collect(),
+            picker,
+        }
+    }
+}
+
+impl<S, P> Service<AnyRequest> for LspSteer<S, P>
+where
+    S: Service<AnyRequest>,
+    P: LspPicker<S>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        for service in &mut self.services {
+            if service.poll_ready(cx).is_pending() {
+                return Poll::Pending;
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: AnyRequest) -> Self::Future {
+        let idx = self.picker.pick(&req, &self.services);
+        self.services[idx].call(req)
+    }
+}
+
+impl<S, P> LspService for LspSteer<S, P>
+where
+    S: LspService,
+    P: LspPicker<S>,
+{
+    fn notify(&mut self, notif: AnyNotification) -> ControlFlow<Result<()>> {
+        let idx = self.picker.pick_notification(&notif, &self.services);
+        self.services[idx].notify(notif)
+    }
+
+    fn emit(&mut self, event: AnyEvent) -> ControlFlow<Result<()>> {
+        let idx = self.picker.pick_event(&event, &self.services);
+        self.services[idx].emit(event)
+    }
+}
+
+// Helper implementation to allow use of closures as LspPicker
+impl<F, S> LspPicker<S> for F
+where
+    F: Fn(&AnyRequest, &[S]) -> usize
+        + Fn(&AnyNotification, &[S]) -> usize
+        + Fn(&AnyEvent, &[S]) -> usize,
+{
+    fn pick(&mut self, req: &AnyRequest, services: &[S]) -> usize {
+        self(req, services)
+    }
+
+    fn pick_notification(&mut self, notif: &AnyNotification, services: &[S]) -> usize {
+        self(notif, services)
+    }
+
+    fn pick_event(&mut self, event: &AnyEvent, services: &[S]) -> usize {
+        self(event, services)
+    }
+}
+
+// Implement `CanHandle` based on inner services:
+impl<S, P> CanHandle<AnyRequest> for LspSteer<S, P>
+where
+    S: CanHandle<AnyRequest>,
+    P: LspPicker<S>,
+{
+    fn can_handle(&self, req: &AnyRequest) -> bool {
+        self.services.iter().any(|service| service.can_handle(req))
+    }
+}
+
+impl<S, P> CanHandle<AnyNotification> for LspSteer<S, P>
+where
+    S: CanHandle<AnyNotification>,
+    P: LspPicker<S>,
+{
+    fn can_handle(&self, notif: &AnyNotification) -> bool {
+        self.services
+            .iter()
+            .any(|service| service.can_handle(notif))
+    }
+}
+
+impl<S, P> CanHandle<AnyEvent> for LspSteer<S, P>
+where
+    S: CanHandle<AnyEvent>,
+    P: LspPicker<S>,
+{
+    fn can_handle(&self, event: &AnyEvent) -> bool {
+        self.services
+            .iter()
+            .any(|service| service.can_handle(event))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{util::BoxLspService, NumberOrString};
+    use std::{future::Future, pin::Pin, sync::Arc};
+
+    struct MockService;
+
+    impl Service<AnyRequest> for MockService {
+        type Response = ();
+        type Error = ();
+        type Future = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: AnyRequest) -> Self::Future {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    impl CanHandle<AnyRequest> for MockService {
+        fn can_handle(&self, _: &AnyRequest) -> bool {
+            true
+        }
+    }
+
+    impl CanHandle<AnyNotification> for MockService {
+        fn can_handle(&self, _: &AnyNotification) -> bool {
+            true
+        }
+    }
+
+    impl CanHandle<AnyEvent> for MockService {
+        fn can_handle(&self, _: &AnyEvent) -> bool {
+            true
+        }
+    }
+
+    impl LspService for MockService {
+        fn notify(&mut self, _: AnyNotification) -> ControlFlow<Result<()>> {
+            ControlFlow::Continue(())
+        }
+
+        fn emit(&mut self, _: AnyEvent) -> ControlFlow<Result<()>> {
+            ControlFlow::Continue(())
+        }
+    }
+
+    struct MockPicker;
+    impl<T> LspPicker<T> for MockPicker {
+        fn pick(&mut self, _: &AnyRequest, _: &[T]) -> usize {
+            0
+        }
+        fn pick_notification(&mut self, _: &AnyNotification, _: &[T]) -> usize {
+            0
+        }
+        fn pick_event(&mut self, _: &AnyEvent, _: &[T]) -> usize {
+            0
+        }
+    }
+
+    #[test]
+    fn test_lsp_steer() {
+        let services = vec![MockService, MockService, MockService];
+        let mut steer = LspSteer::new(services, MockPicker {});
+
+        // Test Service trait
+        let request = AnyRequest {
+            id: NumberOrString::Number(1),
+            method: "test".into(),
+            params: serde_json::Value::Null,
+        };
+        let _future = steer.call(request);
+
+        // Since we can't use block_on, we'll just ensure the future is created
+        // assert!(future.is_pending());
+
+        // Test LspService trait
+        let notification = AnyNotification {
+            method: "test".into(),
+            params: serde_json::Value::Null,
+        };
+        let _ = steer.notify(notification);
+
+        let event = AnyEvent::new(Arc::new("test event"));
+        let _ = steer.emit(event);
+    }
+
+    #[test]
+    fn test_first_come_first_serve() {
+        let services = vec![MockService, MockService, MockService];
+        let picker = FirstComeFirstServe;
+        let mut steer = LspSteer::new(services, picker);
+
+        // Test Service trait
+        let request = AnyRequest {
+            id: NumberOrString::Number(1),
+            method: "test".into(),
+            params: serde_json::Value::Null,
+        };
+        let _future = steer.call(request);
+
+        // Test LspService trait
+        let notification = AnyNotification {
+            method: "test".into(),
+            params: serde_json::Value::Null,
+        };
+        let _ = steer.notify(notification);
+
+        let event = AnyEvent::new(Arc::new("test event"));
+        let _ = steer.emit(event);
+    }
+
+    #[test]
+    fn test_dynamic_first_come_first_serve() {
+        let services = vec![
+            BoxLspService::new(MockService),
+            BoxLspService::new(MockService),
+            BoxLspService::new(MockService),
+        ];
+        let picker = FirstComeFirstServe;
+        let mut steer = LspSteer::new(services, picker);
+
+        // Test Service trait
+        let request = AnyRequest {
+            id: NumberOrString::Number(1),
+            method: "test".into(),
+            params: serde_json::Value::Null,
+        };
+        let _future = steer.call(request);
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,113 @@
+//! Utility types and traits for LSP services.
+//!
+//! This module provides trait definitions and implementations for boxed LSP services,
+//! as well as helper types for working with futures in the context of LSP.
+use crate::can_handle::CanHandle;
+use crate::{AnyEvent, AnyNotification, AnyRequest, LspService, Result};
+use std::future::Future;
+use std::ops::ControlFlow;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower_service::Service;
+
+/// A boxed `Future + Send` trait object.
+pub type BoxFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send>>;
+
+/// Trait combining `LspService`, `CanHandle`, and `Service`, used for type erasure.
+pub trait LspServiceWithCanHandle<Response: 'static, Error: 'static>:
+    LspService
+    + CanHandle<AnyRequest>
+    + CanHandle<AnyNotification>
+    + CanHandle<AnyEvent>
+    + Service<AnyRequest, Future = BoxFuture<Response, Error>>
+where
+    Self::Future: Send + 'static,
+{
+}
+
+impl<T, Response: 'static, Error: 'static> LspServiceWithCanHandle<Response, Error> for T where
+    T: LspService
+        + CanHandle<AnyRequest>
+        + CanHandle<AnyNotification>
+        + CanHandle<AnyEvent>
+        + Service<AnyRequest, Future = BoxFuture<Response, Error>>
+{
+}
+
+/// A boxed `Service + LspService + Send` trait object.
+pub struct BoxLspService<Response, Error> {
+    inner: Box<
+        dyn LspServiceWithCanHandle<Response, Error, Response = Response, Error = Error> + Send,
+    >,
+}
+
+impl<Response: 'static, Error: 'static> BoxLspService<Response, Error> {
+    /// Creates a new `BoxLspService` with the given inner service.
+    ///
+    /// # Arguments
+    ///
+    /// * `inner` - The inner service to be boxed.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `S` - The type of the inner service, which must implement `LspServiceWithCanHandle<Response, Error>`,
+    ///         be `Send`, and have a `'static` lifetime.
+    pub fn new<S>(inner: S) -> Self
+    where
+        S: LspServiceWithCanHandle<Response, Error, Response = Response, Error = Error>
+            + Send
+            + 'static,
+    {
+        BoxLspService {
+            inner: Box::new(inner),
+        }
+    }
+}
+
+impl<R, E> Service<AnyRequest> for BoxLspService<R, E> {
+    type Response = R;
+    type Error = E;
+    type Future = BoxFuture<R, E>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: AnyRequest) -> Self::Future {
+        self.inner.call(request)
+    }
+}
+
+impl<R, E> LspService for BoxLspService<R, E> {
+    fn notify(&mut self, notif: AnyNotification) -> ControlFlow<Result<()>> {
+        self.inner.notify(notif)
+    }
+
+    fn emit(&mut self, event: AnyEvent) -> ControlFlow<Result<()>> {
+        self.inner.emit(event)
+    }
+}
+
+impl<R, E> CanHandle<AnyRequest> for BoxLspService<R, E> {
+    fn can_handle(&self, req: &AnyRequest) -> bool {
+        self.inner.can_handle(req)
+    }
+}
+
+impl<R, E> CanHandle<AnyNotification> for BoxLspService<R, E> {
+    fn can_handle(&self, notif: &AnyNotification) -> bool {
+        self.inner.can_handle(notif)
+    }
+}
+
+impl<R, E> CanHandle<AnyEvent> for BoxLspService<R, E> {
+    fn can_handle(&self, event: &AnyEvent) -> bool {
+        self.inner.can_handle(event)
+    }
+}
+
+impl<R, E> std::fmt::Debug for BoxLspService<R, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoxLspService").finish()
+    }
+}


### PR DESCRIPTION
I wanted to compose two different `LspService` instances in my language server.   I have a custom `LspService` implementation that routes messages to an actor as well as [a trait that generates async streams from an `LspRouter`](https://github.com/micahscopes/fe/blob/language-server-async/crates/language-server/src/lsp_streams.rs).  Tower has a [`Steer`](https://docs.rs/tower/latest/tower/steer/struct.Steer.html) utility that can be used to route messages to different services.  I implemented a `steer` module for async-lsp which features an `LspSteer` service and an `LspPicker` trait for specifying how `LspSteer` should pick services.

I also added a `CanHandle` trait which can be implemented by `LspService` implementations to communicate about which messages they can field.  The implementation for `LspRouter` simply checks to see if there's a handler registered for a given message's key.

Finally, I added a simple `FirstComeFirstServe` picker that uses `CanHandle` methods to find the first service able to handle the message.

Here's how I'm using this in my application: https://github.com/micahscopes/fe/blob/language-server-async/crates/language-server/src/server.rs#L58-L64

```rust
// ...
    let services = vec![
        BoxLspService::new(lsp_actor_service),
        BoxLspService::new(streaming_router),
    ];

    let router = LspSteer::new(services, FirstComeFirstServe);
    BoxLspService::new(router)
```

(If you're curious, the `streaming_router` is currently only used to do some chunked throttling of custom `NeedsDiagnostic` events that get emitted by various update-related handlers.  It then emits another event `FilesNeedDiagnostics` which handles the actual diagnostics.  I'm excited about the potential of combining streams with ordinary `LspRouter` handlers to get more precise control over timing and ordering of message handlers.  That was the motivation for doing it this way.)

By the way, this is an awesome library, thanks for building it!