### PR TITLE
Call `abort()` when ongoing task is removed

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -154,7 +154,9 @@ where
     fn notify(&mut self, notif: AnyNotification) -> ControlFlow<Result<()>> {
         if notif.method == notification::Cancel::METHOD {
             if let Ok(params) = serde_json::from_value::<lsp_types::CancelParams>(notif.params) {
-                self.ongoing.remove(&params.id);
+                if let Some(handle) = self.ongoing.remove(&params.id) {
+                    handle.abort();
+                }
             }
             return ControlFlow::Continue(());
         }


### PR DESCRIPTION
When a `$/cancelRequest` is handled, the concurrency layer only removes the task from the `ongoing` field, but it does not abort it via the `abort()` call. Without this call, there is no way for the ongoing task to attempt to cancel the work that it is doing.

So the change is simple. Just call `abort()` when the task is removed from `ongoing`. This is also what `tower-lsp` does.

By calling `abort()`, one pattern to handle cancellations is by using a drop-guard with a `CancellationTokenSource`:
```rust
    router.request::<request::WillRenameFiles, _>(|state, params: RenameFilesParams| {
        let backend = state.backend.clone();
        async move {
            let cts = CancellationTokenSource::new();
            let _drop_guard = FnDropGuard(|| {
                cts.cancel();
            });
            backend
                .will_rename_files(params, cts.token())
                .await
                .map_err(map_lsp_error)
        }
    });
```
When `abort()` is called, the drop-guard will effectively be called ASAP; marking the `CancellationToken` as cancelled. This means that any other thread/task that captured the `CancellationToken`, then using it to determine if it should cancel any computation based on a request, will now work correctly.

Without calling `abort()`, then this will only happen when the whole task has been completed, which makes cancellation not work as intended.