### PR TITLE
fix!: switch to gen-lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "async-process",
  "criterion",
  "futures",
- "lsp-types",
+ "gen-lsp-types",
  "pin-project-lite",
  "rustix",
  "serde",
@@ -180,12 +180,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -517,6 +511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-lsp-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b8ec601e62362b666a3def1fed667ee87b10a4507402618376d142a05373c6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,19 +621,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
-name = "lsp-types"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
-dependencies = [
- "bitflags 1.3.2",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
 
 [[package]]
 name = "memchr"
@@ -861,7 +853,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -873,12 +865,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -921,26 +907,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zmij",
 ]
 
 [[package]]
@@ -1567,3 +1542,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ harness = false
 async-io = { version = "2", optional = true }
 futures = { version = "0.3.28", default-features = false, features = ["async-await", "std"] }
 # See: https://github.com/gluon-lang/lsp-types/issues/284
-lsp-types = "0.95.0"
+lsp-types = { package = "gen-lsp-types", version = "0.4.0", features = ["url"] }
 pin-project-lite = "0.2.9"
 rustix = { version = "1", optional = true }
 serde = { version = "1.0.159", features = ["derive"] }

--- a/src/client_monitor.rs
+++ b/src/client_monitor.rs
@@ -20,7 +20,7 @@
 use std::ops::ControlFlow;
 use std::task::{Context, Poll};
 
-use lsp_types::request::{self, Request};
+use lsp_types::{InitializeRequest, Request};
 use tower_layer::Layer;
 use tower_service::Service;
 
@@ -47,7 +47,7 @@ impl<S: LspService> Service<AnyRequest> for ClientProcessMonitor<S> {
 
     fn call(&mut self, req: AnyRequest) -> Self::Future {
         if let Some(pid) = (|| -> Option<i32> {
-            (req.method == request::Initialize::METHOD)
+            (req.method == InitializeRequest::METHOD)
                 .then_some(&req.params)?
                 .as_object()?
                 .get("processId")?

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -17,7 +17,7 @@ use std::thread::available_parallelism;
 
 use futures::stream::{AbortHandle, Abortable};
 use futures::task::AtomicWaker;
-use lsp_types::notification::{self, Notification};
+use lsp_types::{json_rpc, CancelNotification, Notification};
 use pin_project_lite::pin_project;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -152,9 +152,13 @@ where
     S::Error: From<ResponseError>,
 {
     fn notify(&mut self, notif: AnyNotification) -> ControlFlow<Result<()>> {
-        if notif.method == notification::Cancel::METHOD {
+        if notif.method == CancelNotification::METHOD {
             if let Ok(params) = serde_json::from_value::<lsp_types::CancelParams>(notif.params) {
-                if let Some(handle) = self.ongoing.remove(&params.id) {
+                let req_id = match params.id {
+                    lsp_types::Id::String(string) => json_rpc::Id::String(string),
+                    lsp_types::Id::Int(int) => json_rpc::Id::Number(int as i64),
+                };
+                if let Some(handle) = self.ongoing.remove(&req_id) {
                     handle.abort();
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,8 @@ use futures::{
     pin_mut, select_biased, AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite,
     AsyncWriteExt, FutureExt, SinkExt, StreamExt,
 };
-use lsp_types::notification::Notification;
-use lsp_types::request::Request;
-use lsp_types::NumberOrString;
+use lsp_types::{LspNotificationMethod, Notification};
+use lsp_types::{LspRequestMethod, Request};
 use pin_project_lite::pin_project;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -304,7 +303,7 @@ impl ErrorCode {
 ///
 /// Though `null` is technically a valid id for responses, we reject it since it hardly makes sense
 /// for valid communication.
-pub type RequestId = NumberOrString;
+pub type RequestId = lsp_types::json_rpc::Id;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct RawMessage<T> {
@@ -343,7 +342,7 @@ pub struct AnyRequest {
     /// The request id.
     pub id: RequestId,
     /// The method to be invoked.
-    pub method: String,
+    pub method: LspRequestMethod,
     /// The method's params.
     #[serde(default)]
     #[serde(skip_serializing_if = "serde_json::Value::is_null")]
@@ -355,7 +354,7 @@ pub struct AnyRequest {
 #[non_exhaustive]
 pub struct AnyNotification {
     /// The method to be invoked.
-    pub method: String,
+    pub method: LspNotificationMethod,
     /// The notification's params.
     #[serde(default)]
     #[serde(skip_serializing_if = "serde_json::Value::is_null")]
@@ -616,7 +615,7 @@ where
     fn dispatch_event(&mut self, event: MainLoopEvent) -> ControlFlow<Result<()>, Option<Message>> {
         match event {
             MainLoopEvent::OutgoingRequest(mut req, resp_tx) => {
-                req.id = RequestId::Number(self.outgoing_id);
+                req.id = RequestId::Number(self.outgoing_id as i64);
                 assert!(self.outgoing.insert(req.id.clone(), resp_tx).is_none());
                 self.outgoing_id += 1;
                 ControlFlow::Continue(Some(Message::Request(req)))
@@ -739,7 +738,7 @@ impl PeerSocket {
     fn request<R: Request>(&self, params: R::Params) -> PeerSocketRequestFuture<R::Result> {
         let req = AnyRequest {
             id: RequestId::Number(0),
-            method: R::METHOD.into(),
+            method: R::METHOD,
             params: serde_json::to_value(params).expect("Failed to serialize"),
         };
         let (tx, rx) = oneshot::channel();
@@ -754,7 +753,7 @@ impl PeerSocket {
 
     fn notify<N: Notification>(&self, params: N::Params) -> Result<()> {
         let notif = AnyNotification {
-            method: N::METHOD.into(),
+            method: N::METHOD,
             params: serde_json::to_value(params).expect("Failed to serialize"),
         };
         self.send(MainLoopEvent::Outgoing(Message::Notification(notif)))
@@ -889,11 +888,11 @@ mod tests {
     async fn closed_client_socket() {
         let socket = ClientSocket::new_closed();
         assert!(matches!(
-            socket.notify::<lsp_types::notification::Exit>(()),
+            socket.notify::<lsp_types::ExitNotification>(()),
             Err(Error::ServiceStopped)
         ));
         assert!(matches!(
-            socket.request::<lsp_types::request::Shutdown>(()).await,
+            socket.request::<lsp_types::ShutdownRequest>(()).await,
             Err(Error::ServiceStopped)
         ));
         assert!(matches!(socket.emit(42i32), Err(Error::ServiceStopped)));
@@ -903,11 +902,11 @@ mod tests {
     async fn closed_server_socket() {
         let socket = ServerSocket::new_closed();
         assert!(matches!(
-            socket.notify::<lsp_types::notification::Exit>(()),
+            socket.notify::<lsp_types::ExitNotification>(()),
             Err(Error::ServiceStopped)
         ));
         assert!(matches!(
-            socket.request::<lsp_types::request::Shutdown>(()).await,
+            socket.request::<lsp_types::ShutdownRequest>(()).await,
             Err(Error::ServiceStopped)
         ));
         assert!(matches!(socket.emit(42i32), Err(Error::ServiceStopped)));

--- a/src/omni_trait.rs
+++ b/src/omni_trait.rs
@@ -2,9 +2,10 @@ use std::future::ready;
 use std::ops::ControlFlow;
 
 use futures::future::BoxFuture;
-use lsp_types::notification::{self, Notification};
-use lsp_types::request::{self, Request};
-use lsp_types::{lsp_notification, lsp_request};
+use lsp_types::{
+    lsp_notification, lsp_request, ExitNotification, InitializeRequest, InitializedNotification,
+    Notification, Request, ShutdownRequest,
+};
 
 use crate::router::Router;
 use crate::{ClientSocket, ErrorCode, ResponseError, Result, ServerSocket};
@@ -12,6 +13,8 @@ use crate::{ClientSocket, ErrorCode, ResponseError, Result, ServerSocket};
 use self::sealed::NotifyResult;
 
 mod sealed {
+    use lsp_types::{ExitNotification, InitializedNotification};
+
     use super::*;
 
     pub trait NotifyResult {
@@ -20,9 +23,9 @@ mod sealed {
 
     impl NotifyResult for ControlFlow<crate::Result<()>> {
         fn fallback<N: Notification>() -> Self {
-            if N::METHOD.starts_with("$/")
-                || N::METHOD == notification::Exit::METHOD
-                || N::METHOD == notification::Initialized::METHOD
+            if N::METHOD.as_str().starts_with("$/")
+                || N::METHOD == ExitNotification::METHOD
+                || N::METHOD == InitializedNotification::METHOD
             {
                 ControlFlow::Continue(())
             } else {
@@ -94,14 +97,14 @@ macro_rules! define_server {
             #[must_use]
             fn initialize(
                 &mut self,
-                params: <request::Initialize as Request>::Params,
-            ) -> ResponseFuture<request::Initialize, Self::Error>;
+                params: <InitializeRequest as Request>::Params,
+            ) -> ResponseFuture<InitializeRequest, Self::Error>;
 
             #[must_use]
             fn shutdown(
                 &mut self,
-                (): <request::Shutdown as Request>::Params,
-            ) -> ResponseFuture<request::Shutdown, Self::Error> {
+                (): <ShutdownRequest as Request>::Params,
+            ) -> ResponseFuture<ShutdownRequest, Self::Error> {
                 Box::pin(ready(Ok(())))
             }
 
@@ -121,18 +124,18 @@ macro_rules! define_server {
             #[must_use]
             fn initialized(
                 &mut self,
-                params: <notification::Initialized as Notification>::Params,
+                params: <InitializedNotification as Notification>::Params,
             ) -> Self::NotifyResult {
                 let _ = params;
-                Self::NotifyResult::fallback::<notification::Initialized>()
+                Self::NotifyResult::fallback::<InitializedNotification>()
             }
 
             #[must_use]
             fn exit(
                 &mut self,
-                (): <notification::Exit as Notification>::Params,
+                (): <ExitNotification as Notification>::Params,
             ) -> Self::NotifyResult {
-                Self::NotifyResult::fallback::<notification::Exit>()
+                Self::NotifyResult::fallback::<ExitNotification>()
             }
 
             $(
@@ -157,16 +160,16 @@ macro_rules! define_server {
 
                     fn initialize(
                         &mut self,
-                        params: <request::Initialize as Request>::Params,
-                    ) -> ResponseFuture<request::Initialize, Self::Error> {
-                        Box::pin(self.0.request::<request::Initialize>(params))
+                        params: <InitializeRequest as Request>::Params,
+                    ) -> ResponseFuture<InitializeRequest, Self::Error> {
+                        Box::pin(self.0.request::<InitializeRequest>(params))
                     }
 
                     fn shutdown(
                         &mut self,
-                        (): <request::Shutdown as Request>::Params,
-                    ) -> ResponseFuture<request::Shutdown, Self::Error> {
-                        Box::pin(self.0.request::<request::Shutdown>(()))
+                        (): <ShutdownRequest as Request>::Params,
+                    ) -> ResponseFuture<ShutdownRequest, Self::Error> {
+                        Box::pin(self.0.request::<ShutdownRequest>(()))
                     }
 
                     $(
@@ -182,16 +185,16 @@ macro_rules! define_server {
 
                     fn initialized(
                         &mut self,
-                        params: <notification::Initialized as Notification>::Params,
+                        params: <InitializedNotification as Notification>::Params,
                     ) -> Self::NotifyResult {
-                        self.notify::<notification::Initialized>(params)
+                        self.notify::<InitializedNotification>(params)
                     }
 
                     fn exit(
                         &mut self,
-                        (): <notification::Exit as Notification>::Params,
+                        (): <ExitNotification as Notification>::Params,
                     ) -> Self::NotifyResult {
-                        self.notify::<notification::Exit>(())
+                        self.notify::<ExitNotification>(())
                     }
 
                     $(
@@ -218,11 +221,11 @@ macro_rules! define_server {
             #[must_use]
             pub fn from_language_server(state: S) -> Self {
                 let mut this = Self::new(state);
-                this.request::<request::Initialize, _>(|state, params| {
+                this.request::<InitializeRequest, _>(|state, params| {
                     let fut = state.initialize(params);
                     async move { fut.await.map_err(Into::into) }
                 });
-                this.request::<request::Shutdown, _>(|state, params| {
+                this.request::<ShutdownRequest, _>(|state, params| {
                     let fut = state.shutdown(params);
                     async move { fut.await.map_err(Into::into) }
                 });
@@ -230,8 +233,8 @@ macro_rules! define_server {
                     let fut = state.$req_snake(params);
                     async move { fut.await.map_err(Into::into) }
                 });)*
-                this.notification::<notification::Initialized>(|state, params| state.initialized(params));
-                this.notification::<notification::Exit>(|state, params| state.exit(params));
+                this.notification::<InitializedNotification>(|state, params| state.initialized(params));
+                this.notification::<ExitNotification>(|state, params| state.exit(params));
                 $(this.notification::<$notif>(|state, params| state.$notif_snake(params));)*
                 this
             }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -8,6 +8,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use lsp_types::LspRequestMethod;
 use pin_project_lite::pin_project;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -24,9 +25,9 @@ pub struct CatchUnwind<S: LspService> {
 
 define_getters!(impl[S: LspService] CatchUnwind<S>, service: S);
 
-type Handler<E> = fn(method: &str, payload: Box<dyn Any + Send>) -> E;
+type Handler<E> = fn(method: LspRequestMethod, payload: Box<dyn Any + Send>) -> E;
 
-fn default_handler(method: &str, payload: Box<dyn Any + Send>) -> ResponseError {
+fn default_handler(method: LspRequestMethod, payload: Box<dyn Any + Send>) -> ResponseError {
     let msg = match payload.downcast::<String>() {
         Ok(msg) => *msg,
         Err(payload) => match payload.downcast::<&'static str>() {
@@ -54,7 +55,7 @@ impl<S: LspService> Service<AnyRequest> for CatchUnwind<S> {
         let method = req.method.clone();
         // FIXME: Clarify conditions of UnwindSafe.
         match catch_unwind(AssertUnwindSafe(|| self.service.call(req)))
-            .map_err(|err| (self.handler)(&method, err))
+            .map_err(|err| (self.handler)(method.clone(), err))
         {
             Ok(fut) => ResponseFuture {
                 inner: ResponseFutureInner::Future {
@@ -84,7 +85,7 @@ pin_project! {
         Future {
             #[pin]
             fut: Fut,
-            method: String,
+            method: LspRequestMethod,
             handler: Handler<Error>,
         },
         Ready {
@@ -109,7 +110,7 @@ where
                 // FIXME: Clarify conditions of UnwindSafe.
                 match catch_unwind(AssertUnwindSafe(|| fut.poll(cx))) {
                     Ok(poll) => poll,
-                    Err(payload) => Poll::Ready(Err(handler(method, payload))),
+                    Err(payload) => Poll::Ready(Err(handler(method.clone(), payload))),
                 }
             }
             ResponseFutureProj::Ready { err } => Poll::Ready(Err(err.take().expect("Completed"))),

--- a/src/router.rs
+++ b/src/router.rs
@@ -6,8 +6,8 @@ use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use lsp_types::notification::Notification;
-use lsp_types::request::Request;
+use lsp_types::Request;
+use lsp_types::{LspNotificationMethod, LspRequestMethod, Notification};
 use tower_service::Service;
 
 use crate::{
@@ -17,8 +17,8 @@ use crate::{
 /// A router dispatching requests and notifications to individual handlers.
 pub struct Router<St, Error = ResponseError> {
     state: St,
-    req_handlers: HashMap<&'static str, BoxReqHandler<St, Error>>,
-    notif_handlers: HashMap<&'static str, BoxNotifHandler<St>>,
+    req_handlers: HashMap<LspRequestMethod, BoxReqHandler<St, Error>>,
+    notif_handlers: HashMap<LspNotificationMethod, BoxNotifHandler<St>>,
     event_handlers: HashMap<TypeId, BoxEventHandler<St>>,
     unhandled_req: BoxReqHandler<St, Error>,
     unhandled_notif: BoxNotifHandler<St>,
@@ -62,7 +62,7 @@ where
                 .into())))
             }),
             unhandled_notif: Box::new(|_, notif| {
-                if notif.method.starts_with("$/") {
+                if notif.method.as_str().starts_with("$/") {
                     ControlFlow::Continue(())
                 } else {
                     ControlFlow::Break(Err(crate::Error::Routing(format!(
@@ -212,7 +212,7 @@ impl<St, Error> Service<AnyRequest> for Router<St, Error> {
     fn call(&mut self, req: AnyRequest) -> Self::Future {
         let h = self
             .req_handlers
-            .get(&*req.method)
+            .get(&req.method)
             .unwrap_or(&self.unhandled_req);
         h(&mut self.state, req)
     }
@@ -222,7 +222,7 @@ impl<St> LspService for Router<St> {
     fn notify(&mut self, notif: AnyNotification) -> ControlFlow<Result<()>> {
         let h = self
             .notif_handlers
-            .get(&*notif.method)
+            .get(&notif.method)
             .unwrap_or(&self.unhandled_notif);
         h(&mut self.state, notif)
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,8 +14,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures::future::Either;
-use lsp_types::notification::{self, Notification};
-use lsp_types::request::{self, Request};
+use lsp_types::{ExitNotification, InitializedNotification, Notification, ShutdownRequest};
+use lsp_types::{InitializeRequest, Request};
 use pin_project_lite::pin_project;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -68,8 +68,8 @@ where
     }
 
     fn call(&mut self, req: AnyRequest) -> Self::Future {
-        let inner = match (self.state, &*req.method) {
-            (State::Uninitialized, request::Initialize::METHOD) => {
+        let inner = match (self.state, &req.method) {
+            (State::Uninitialized, &InitializeRequest::METHOD) => {
                 self.state = State::Initializing;
                 Either::Left(self.service.call(req))
             }
@@ -81,14 +81,14 @@ where
                 }
                 .into())))
             }
-            (_, request::Initialize::METHOD) => Either::Right(ready(Err(ResponseError {
+            (_, &InitializeRequest::METHOD) => Either::Right(ready(Err(ResponseError {
                 code: ErrorCode::INVALID_REQUEST,
                 message: "Server is already initialized".into(),
                 data: None,
             }
             .into()))),
             (State::Ready, _) => {
-                if req.method == request::Shutdown::METHOD {
+                if req.method == ShutdownRequest::METHOD {
                     self.state = State::ShuttingDown;
                 }
                 Either::Left(self.service.call(req))
@@ -109,12 +109,12 @@ where
     S::Error: From<ResponseError>,
 {
     fn notify(&mut self, notif: AnyNotification) -> ControlFlow<Result<()>> {
-        match &*notif.method {
-            notification::Exit::METHOD => {
+        match notif.method {
+            ExitNotification::METHOD => {
                 self.service.notify(notif)?;
                 ControlFlow::Break(Ok(()))
             }
-            notification::Initialized::METHOD => {
+            InitializedNotification::METHOD => {
                 if self.state != State::Initializing {
                     return ControlFlow::Break(Err(Error::Protocol(format!(
                         "Unexpected initialized notification on state {:?}",

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -97,8 +97,8 @@ impl Default for TracingBuilder {
     fn default() -> Self {
         Self {
             service_ready: Some(|| info_span!("service_ready")),
-            request: Some(|req| info_span!("request", method = req.method)),
-            notification: Some(|notif| info_span!("notification", method = notif.method)),
+            request: Some(|req| info_span!("request", method = req.method.as_str())),
+            notification: Some(|notif| info_span!("notification", method = notif.method.as_str())),
             event: Some(|event| info_span!("event", type_name = event.type_name())),
         }
     }


### PR DESCRIPTION
[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) addresses a number of issues in the lsp-types crate, but it will mean that downstream users must switch as well when updating to the new version of this library.